### PR TITLE
Print Out Offending File When Uglify-JS Fails

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -202,13 +202,20 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp, c
       case 'uglify':
         if (results instanceof Array)
           results = results.join("\n");
-        var final_code = uglify.minify(results, {
-          fromString: true,
-          output: {
-            comments: /license/
-          }
-        }).code;
-        pushFileToS3(S3, final_code, fileName, headers, callback);
+        try {
+          var final_code = uglify.minify(results, {
+            fromString: true,
+            output: {
+              comments: /license/
+            }
+          }).code;
+          pushFileToS3(S3, final_code, fileName, headers, callback);
+        } catch(err) {
+          logger({
+            task: 'express-cdn',
+            message: 'Failed to minify ' + fileName + ' due to uglify-js error.'})
+          throw err
+        }
         break;
       case 'minify':
         if (!(results instanceof Array)) {


### PR DESCRIPTION
UglifyJS can fail for good reasons such as:
1. Static checker found bad codes (i.e. unclosed parenthesis)
2. ES6 is used in browser asset JS.

Printing the file name helps with debugging.